### PR TITLE
pythonを実行する順番が異なっていたため

### DIFF
--- a/dlbin/dl_1_init.sh
+++ b/dlbin/dl_1_init.sh
@@ -8,8 +8,17 @@ CURRENT=$(cd $(dirname $0) && pwd)
 
 cd $PYTHON_DIR
 echo "[START] make_train_data"
-python ./make_train_data.py $DATA_DIR
-echo "[START] compute_mean"
-python ./compute_mean.py -o $DATA_DIR/mean.npy $DATA_DIR/train.txt
+rm $DATA_DIR/mean.npy > /dev/null 2>&1
+rm $DATA_DIR/train.txt > /dev/null 2>&1
+rm $DATA_DIR/test.txt > /dev/null 2>&1
+rm $DATA_DIR/labels.txt > /dev/null 2>&1
+rm $DATA_DIR/images/* > /dev/null 2>&1
+rm $DATA_DIR/tmpimages/* > /dev/null 2>&1
+python ./make_train_data.py -s $DATA_DIR/mstimages \
+        -o $DATA_DIR/images -t $DATA_DIR/train.txt -e $DATA_DIR/test.txt \
+        -l $DATA_DIR/labels.txt
 echo "[START] crop"
-python ./crop.py $DATA_DIR/images $DATA_DIR/images
+mv $DATA_DIR/images/* $DATA_DIR/tmpimages
+python ./crop.py $DATA_DIR/tmpimages $DATA_DIR/images
+echo "[START] compute_mean"
+python ./compute_mean.py -o $DATA_DIR/mean.npy $DATA_DIR/train.txt > /tmp/test2.txt

--- a/python/compute_mean.py
+++ b/python/compute_mean.py
@@ -2,7 +2,7 @@
 import argparse
 import sys
 
-import numpy
+import numpy as np
 from PIL import Image
 import six.moves.cPickle as pickle
 
@@ -17,9 +17,10 @@ sum_image = None
 count = 0
 for line in open(args.dataset):
     filepath = line.strip().split()[0]
-    image = numpy.asarray(Image.open(filepath)).transpose(2, 0, 1)
+    image = np.asarray(Image.open(filepath)).transpose(2, 0, 1)
+    #print filepath
     if sum_image is None:
-        sum_image = numpy.ndarray(image.shape, dtype=numpy.float32)
+        sum_image = np.ndarray(image.shape, dtype=np.float32)
         sum_image[:] = image
     else:
         sum_image += image

--- a/python/make_train_data.py
+++ b/python/make_train_data.py
@@ -1,6 +1,15 @@
 import sys
 import commands
 import subprocess
+import argparse
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--source_dir', '-s')
+parser.add_argument('--target_dir', '-o')
+parser.add_argument('--labels', '-l', default='train.txt')
+parser.add_argument('--train', '-t', default='train.txt')
+parser.add_argument('--test', '-e', default='test.txt')
+args = parser.parse_args()
 
 def cmd(cmd):
 	p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -9,24 +18,23 @@ def cmd(cmd):
 	return stdout.rstrip()
 
 #labels
-data_dir = sys.argv[1]
-dirs = cmd("ls %s/mstimages" % data_dir)
+dirs = cmd("ls %s" % args.source_dir)
 labels = dirs.splitlines()
 
 #make directries
-cmd("mkdir %s/images" % data_dir)
+cmd(args.target_dir)
 
 #copy images and make train.txt
-imageDir = "%s/images" % data_dir
-train = open("%s/train.txt" % data_dir,'w')
-test = open("%s/test.txt" % data_dir,'w')
-labelsTxt = open("%s/labels.txt" % data_dir,'w')
+imageDir = args.target_dir
+train = open(args.train, 'w')
+test = open(args.test,'w')
+labelsTxt = open(args.labels,'w')
 
 classNo=0
 cnt = 0
 #label = labels[classNo]
 for label in labels:
-	workdir = "%s/mstimages/%s" % (data_dir, label)
+	workdir = "%s/%s" % (args.source_dir, label)
 	imageFiles = cmd("ls %s/*.jpg" % workdir)
 	images = imageFiles.splitlines()
 


### PR DESCRIPTION
原因はシェルを実行する順番が違っていたため。
cropで正規化してから計算しなければならない。
コマンドラインで実行した時は、何故かイメージを256×256で必ず計算していた。
